### PR TITLE
Add support for localized usernames

### DIFF
--- a/yubiauth/core/rest.py
+++ b/yubiauth/core/rest.py
@@ -37,7 +37,7 @@ from yubiauth.util.rest import (
     REST_API, Route, no_content, json_response, json_error, extract_params)
 
 ID_PATTERN = r'\d+'
-USERNAME_PATTERN = r'(?=.*[a-zA-Z])[-_a-zA-Z0-9]{3,}'
+USERNAME_PATTERN = '(?=.*[a-zA-Z\xc0-\xff])[-_a-zA-Z0-9\xc0-\xff]{3,}'
 PASSWORD_PATTERN = r'\S{3,}'
 YUBIKEY_PATTERN = r'[%s]{0,64}' % MODHEX
 ATTRIBUTE_KEY_PATTERN = r'[-_a-zA-Z0-9]+'


### PR DESCRIPTION
## What it is

It's quite a simple change, it enables functioning users with (some) non-ascii characters.
## Example
### Get name to use with queries

```
$ python
>>> import urllib
>>> urllib.quote(u"åsa".encode("utf-8"))
'%C3%A5sa'
```
### Without patch

```
$ curl http://127.0.0.1:8080/core/users --data "username=%C3%A5sa&password=loesen"
{"id": 2, "name": "\u00e5sa"}
$ curl "http://127.0.0.1:8080/core/users/%C3%A5sa/yubikeys" --data "yubikey=ccccccdbrlch"  
<html>
 <head>
  <title>404 Not Found</title>
 </head>
 <body>
  <h1>404 Not Found</h1>
  The resource could not be found.<br /><br />



 </body>
</html>
$ curl "http://127.0.0.1:8080/core/users/%C3%A5sa"
<html>
 <head>
  <title>404 Not Found</title>
 </head>
 <body>
  <h1>404 Not Found</h1>
  The resource could not be found.<br /><br />



 </body>
</html>
$ curl "http://127.0.0.1:8080/core/users/1"
{"attributes": {}, "yubikeys": [], "id": 1, "name": "\u00e5sa"}
```
### With patch

```
$ curl http://127.0.0.1:8080/core/users --data "username=%C3%A5sa&password=loesen"
{"id": 1, "name": "\u00e5sa"}
$ curl "http://127.0.0.1:8080/core/users/%C3%A5sa/yubikeys" --data "yubikey=ccccccdbrlch"
$ curl "http://127.0.0.1:8080/core/users/%C3%A5sa"
{"attributes": {}, "yubikeys": ["ccccccdbrlch"], "id": 1, "name": "\u00e5sa"}
```
